### PR TITLE
Update ispeech_fr.csv

### DIFF
--- a/voice/fr/ispeech_fr.csv
+++ b/voice/fr/ispeech_fr.csv
@@ -1,5 +1,5 @@
-route_is.ogg,l'itinéraire fait  
-route_calculate.ogg,itinéraire recalculé
+route_is.ogg,L'itinéraire fait  
+route_calculate.ogg,Itinéraire recalculé
 distance.ogg,  l'itinéraire fait 
 prepare.ogg,préparez vous à 
 after.ogg,dans 
@@ -17,8 +17,8 @@ pr2left_sl.ogg,tourner légèrement à gauche
 pr2right.ogg,tourner à droite 
 pr2right_sh.ogg,tourner immédiatement à droite 
 pr2right_sl.ogg,tourner légèrement à droite 
-pr2right_keep.ogg,serrer à droite 
-pr2left_keep.ogg,serrer à gauche 
+pr2right_keep.ogg,rester à droite 
+pr2left_keep.ogg,rester à gauche 
 prepare_make_uturn.ogg,préparez vous à faire demi-tour
 make_uturn.ogg, faites demi-tour 
 make_uturn_wp.ogg,Dès que possible  faites demi-tour 
@@ -48,16 +48,16 @@ exit.ogg,sortie
 go_ahead.ogg,Continuez tout droit 
 follow.ogg,Continuez pendant 
 and_arrive_destination.ogg,et arrivez à destination 
-reached_destination.ogg,vous êtes arrivé à destination 
+reached_destination.ogg,Vous êtes arrivé à destination 
 and_arrive_intermediate.ogg,et arrivez à l'étape 
-reached_intermediate.ogg,vous êtes arrivé à l'étape
+reached_intermediate.ogg,Vous êtes arrivé à l'étape
 and_arrive_waypoint.ogg,et arrivez à l'étape G P X 
-reached_waypoint.ogg,vous êtes arrivé à l'étape G P X
-attention.ogg,attention   
-location_lost.ogg,localisation perdue 
-location_recovered.ogg,localisation retrouvée 
-off_route.ogg,vous avez dévié de l'itinéraire depuis
-exceed_limit.ogg,vous dépassez la limite de vitesse 
+reached_waypoint.ogg,Vous êtes arrivé à l'étape G P X
+attention.ogg,Attention   
+location_lost.ogg,Localisation perdue 
+location_recovered.ogg,Localisation retrouvée 
+off_route.ogg,Vous avez dévié de l'itinéraire depuis
+exceed_limit.ogg,Vous dépassez la limite de vitesse 
 onto.ogg,sur 
 on.ogg,sur 
 to.ogg,vers 

--- a/voice/fr/ispeech_fr.csv
+++ b/voice/fr/ispeech_fr.csv
@@ -1,5 +1,5 @@
 route_is.ogg,l'itinéraire fait  
-route_calculate.ogg,recalcul de l'itinéraire
+route_calculate.ogg,itinéraire recalculé
 distance.ogg,  l'itinéraire fait 
 prepare.ogg,préparez vous à 
 after.ogg,dans 
@@ -9,8 +9,8 @@ left_sl.ogg,tournez légèrement à gauche
 right.ogg,tournez à droite 
 right_sh.ogg,tournez immédiatement à droite 
 right_sl.ogg,tournez légèrement à droite 
-left_keep.ogg,serrez à gauche 
-right_keep.ogg,serrez à droite 
+left_keep.ogg,restez à gauche 
+right_keep.ogg,restez à droite 
 pr2left.ogg,tourner à gauche 
 pr2left_sh.ogg,tourner immédiatement à gauche 
 pr2left_sl.ogg,tourner légèrement à gauche 
@@ -19,7 +19,7 @@ pr2right_sh.ogg,tourner immédiatement à droite
 pr2right_sl.ogg,tourner légèrement à droite 
 pr2right_keep.ogg,serrer à droite 
 pr2left_keep.ogg,serrer à gauche 
-prepare_make_uturn.ogg,préparez vous à faire demi tour
+prepare_make_uturn.ogg,préparez vous à faire demi-tour
 make_uturn.ogg, faites demi-tour 
 make_uturn_wp.ogg,Dès que possible  faites demi-tour 
 prepare_roundabout.ogg,Préparez vous à entrer dans le rond-point dans 
@@ -54,8 +54,8 @@ reached_intermediate.ogg,vous êtes arrivé à l'étape
 and_arrive_waypoint.ogg,et arrivez à l'étape G P X 
 reached_waypoint.ogg,vous êtes arrivé à l'étape G P X
 attention.ogg,attention   
-location_lost.ogg,signal G P S perdu 
-location_recovered.ogg,signal G P S restaurés 
+location_lost.ogg,localisation perdue 
+location_recovered.ogg,localisation retrouvée 
 off_route.ogg,vous avez dévié de l'itinéraire depuis
 exceed_limit.ogg,vous dépassez la limite de vitesse 
 onto.ogg,sur 


### PR DESCRIPTION
"Location lost/recovered" was previously translated to "Signal GPS perdu/retrouvé" (= "GPS signal lost/recovered").

However :
- GPS is only one of the several existing satellite positionning systems (GLONASS, Beidou, later Galileo) 
- Satellite positionning is not the only existing positionning : cell towers, wifi hotspots, later Bluetooth and other technologies (RID/NFC tags ?) can be used as well
- Location can be lost even though GPS signal (or signals) has not been lost

For those reasons, I propose a more correct translation of "Localisation perdue/retrouvée"


Also :
- "route_calculate.ogg" is played when the calculation is over, hence "itinéraire recalculé"
- disambiguation of "serrez/restez"